### PR TITLE
Allow leeway when validating iat and nbf claims

### DIFF
--- a/claims.go
+++ b/claims.go
@@ -68,7 +68,7 @@ func (c StandardClaims) Valid() error {
 
 // Allow sets allowed leeway when validating claims nbf and iat.
 func (c StandardClaims) Allow(n time.Duration) Claims {
-	c.leeway = n.Milliseconds() / 1000
+	c.leeway = n.Microseconds() / 1000000
 	return c
 }
 

--- a/claims.go
+++ b/claims.go
@@ -15,8 +15,7 @@ type Claims interface {
 
 // LeewayClaim allows to set leeway when validating iat and/or nbf claim.
 type LeewayClaim interface {
-	Claims
-	Leeway(n time.Duration) LeewayClaim
+	Leeway(n time.Duration) Claims
 }
 
 // Structured version of Claims Section, as referenced at

--- a/claims.go
+++ b/claims.go
@@ -68,7 +68,7 @@ func (c StandardClaims) Valid() error {
 
 // Allow sets allowed leeway when validating claims nbf and iat.
 func (c StandardClaims) Allow(n time.Duration) Claims {
-	c.leeway = n.Microseconds() / 1000000
+	c.leeway = int64(n.Seconds())
 	return c
 }
 

--- a/claims.go
+++ b/claims.go
@@ -31,7 +31,7 @@ type StandardClaims struct {
 	Issuer    string   `json:"iss,omitempty"`
 	NotBefore int64    `json:"nbf,omitempty"`
 	Subject   string   `json:"sub,omitempty"`
-	leeway    int64    `json:"-"`
+	leeway    int64
 }
 
 // Validates time based claims "exp, iat, nbf", as well, if any of the claims

--- a/claims.go
+++ b/claims.go
@@ -13,9 +13,11 @@ type Claims interface {
 	Valid() error
 }
 
-// LeewayClaim allows to set leeway when validating iat and/or nbf claim.
-type LeewayClaim interface {
-	Leeway(n time.Duration) Claims
+// Leeway must support the following.
+//
+// - Allow set allowed leeway when validating iat and/or nbf claim.
+type Leeway interface {
+	Allow(n time.Duration) Claims
 }
 
 // Structured version of Claims Section, as referenced at
@@ -33,7 +35,8 @@ type StandardClaims struct {
 }
 
 // Validates time based claims "exp, iat, nbf", as well, if any of the claims
-// are not in the token, it will still be considered a valid claim.
+// are not in the token, it will still be considered a valid claim. Leeway can
+// be applied when optional through Leeway.Allow() through calling routine.
 func (c StandardClaims) Valid() error {
 	vErr := new(ValidationError)
 	now := TimeFunc().Unix()
@@ -63,8 +66,8 @@ func (c StandardClaims) Valid() error {
 	return vErr
 }
 
-// Leeway sets leeway when validating claims nbf and iat.
-func (c StandardClaims) Leeway(n time.Duration) Claims {
+// Allow sets allowed leeway when validating claims nbf and iat.
+func (c StandardClaims) Allow(n time.Duration) Claims {
 	c.leeway = n.Milliseconds() / 1000
 	return c
 }

--- a/hmac_example_test.go
+++ b/hmac_example_test.go
@@ -51,7 +51,7 @@ func ExampleParse_hmac() {
 		if _, ok := token.Method.(*jwt.SigningMethodHMAC); !ok {
 			return nil, fmt.Errorf("Unexpected signing method: %v", token.Header["alg"])
 		}
-		
+
 		// hmacSampleSecret is a []byte containing your secret, e.g. []byte("my_secret_key")
 		return hmacSampleSecret, nil
 	})

--- a/map_claims.go
+++ b/map_claims.go
@@ -3,32 +3,45 @@ package jwt
 import (
 	"encoding/json"
 	"errors"
-	// "fmt"
+	"time"
 )
 
 // Claims type that uses the map[string]interface{} for JSON decoding
-// This is the default claims type if you don't supply one
-type MapClaims map[string]interface{}
+// This is the default claims type if you don't supply one.
+type MapClaim map[string]interface{}
+
+type MapClaims struct {
+	MapClaim
+	leeway int64
+}
+
+func (m MapClaim) set(k string, v interface{}) MapClaim {
+	m[k] = v
+	return m
+}
+
+func (m MapClaim) get(k string) interface{} {
+	return m[k]
+}
 
 // Compares the aud claim against cmp.
 // If required is false, this method will return true if the value matches or is unset
 func (m MapClaims) VerifyAudience(cmp string, req bool) bool {
-	aud, ok := m["aud"].([]string)
+	aud, ok := m.get("aud").([]string)
 	if !ok {
-		strAud, ok := m["aud"].(string)
+		strAud, ok := m.get("aud").(string)
 		if !ok {
 			return false
 		}
 		aud = append(aud, strAud)
 	}
-
 	return verifyAud(aud, cmp, req)
 }
 
 // Compares the exp claim against cmp.
 // If required is false, this method will return true if the value matches or is unset
 func (m MapClaims) VerifyExpiresAt(cmp int64, req bool) bool {
-	switch exp := m["exp"].(type) {
+	switch exp := m.get("exp").(type) {
 	case float64:
 		return verifyExp(int64(exp), cmp, req)
 	case json.Number:
@@ -41,12 +54,12 @@ func (m MapClaims) VerifyExpiresAt(cmp int64, req bool) bool {
 // Compares the iat claim against cmp.
 // If required is false, this method will return true if the value matches or is unset
 func (m MapClaims) VerifyIssuedAt(cmp int64, req bool) bool {
-	switch iat := m["iat"].(type) {
+	switch iat := m.get("iat").(type) {
 	case float64:
-		return verifyIat(int64(iat), cmp, req)
+		return verifyIat(int64(iat)-m.leeway, cmp, req)
 	case json.Number:
 		v, _ := iat.Int64()
-		return verifyIat(v, cmp, req)
+		return verifyIat(v-m.leeway, cmp, req)
 	}
 	return req == false
 }
@@ -54,21 +67,30 @@ func (m MapClaims) VerifyIssuedAt(cmp int64, req bool) bool {
 // Compares the iss claim against cmp.
 // If required is false, this method will return true if the value matches or is unset
 func (m MapClaims) VerifyIssuer(cmp string, req bool) bool {
-	iss, _ := m["iss"].(string)
+	iss, _ := m.get("iss").(string)
 	return verifyIss(iss, cmp, req)
 }
 
 // Compares the nbf claim against cmp.
 // If required is false, this method will return true if the value matches or is unset
 func (m MapClaims) VerifyNotBefore(cmp int64, req bool) bool {
-	switch nbf := m["nbf"].(type) {
+	switch nbf := m.get("nbf").(type) {
 	case float64:
-		return verifyNbf(int64(nbf), cmp, req)
+		return verifyNbf(int64(nbf)-m.leeway, cmp, req)
 	case json.Number:
 		v, _ := nbf.Int64()
-		return verifyNbf(v, cmp, req)
+		return verifyNbf(v-m.leeway, cmp, req)
 	}
 	return req == false
+}
+
+// Leeway sets leeway for validation of claims:
+// - Not Before
+// - Issued At
+// Length of leeway should only be a few minutes.
+func (m MapClaims) Leeway(n time.Duration) Claims {
+	m.leeway = n.Milliseconds() / 1000
+	return m
 }
 
 // Validates time based claims "exp, iat, nbf".

--- a/map_claims_test.go
+++ b/map_claims_test.go
@@ -3,38 +3,57 @@ package jwt
 import "testing"
 
 func Test_mapClaims_list_aud(t *testing.T) {
-	mapClaims := MapClaims{}
-	mapClaims["aud"] = []string{"foo"}
+	mapClaims := MapClaims{
+		"aud": []string{"foo"},
+	}
 	want := true
 	got := mapClaims.VerifyAudience("foo", true)
+
+	if want != got {
+		t.Fatalf("Failed to verify claims, wanted: %v got %v", want, got)
+	}
+}
+func Test_mapClaims_list_interface_aud(t *testing.T) {
+	mapClaims := MapClaims{
+		"aud": []interface{}{"foo"},
+	}
+	want := true
+	got := mapClaims.VerifyAudience("foo", true)
+
 	if want != got {
 		t.Fatalf("Failed to verify claims, wanted: %v got %v", want, got)
 	}
 }
 func Test_mapClaims_string_aud(t *testing.T) {
-	mapClaims := MapClaims{}
-	mapClaims["aud"] = "foo"
+	mapClaims := MapClaims{
+		"aud": "foo",
+	}
 	want := true
 	got := mapClaims.VerifyAudience("foo", true)
+
 	if want != got {
 		t.Fatalf("Failed to verify claims, wanted: %v got %v", want, got)
 	}
 }
 
 func Test_mapClaims_list_aud_no_match(t *testing.T) {
-	mapClaims := MapClaims{}
-	mapClaims["aud"] = []string{"bar"}
+	mapClaims := MapClaims{
+		"aud": []string{"bar"},
+	}
 	want := false
 	got := mapClaims.VerifyAudience("foo", true)
+
 	if want != got {
 		t.Fatalf("Failed to verify claims, wanted: %v got %v", want, got)
 	}
 }
 func Test_mapClaims_string_aud_fail(t *testing.T) {
-	mapClaims := MapClaims{}
-	mapClaims["aud"] = "bar"
+	mapClaims := MapClaims{
+		"aud": "bar",
+	}
 	want := false
 	got := mapClaims.VerifyAudience("foo", true)
+
 	if want != got {
 		t.Fatalf("Failed to verify claims, wanted: %v got %v", want, got)
 	}
@@ -44,6 +63,7 @@ func Test_mapClaims_string_aud_no_claim(t *testing.T) {
 	mapClaims := MapClaims{}
 	want := false
 	got := mapClaims.VerifyAudience("foo", true)
+
 	if want != got {
 		t.Fatalf("Failed to verify claims, wanted: %v got %v", want, got)
 	}
@@ -53,6 +73,7 @@ func Test_mapClaims_string_aud_no_claim_not_required(t *testing.T) {
 	mapClaims := MapClaims{}
 	want := false
 	got := mapClaims.VerifyAudience("foo", false)
+
 	if want != got {
 		t.Fatalf("Failed to verify claims, wanted: %v got %v", want, got)
 	}

--- a/map_claims_test.go
+++ b/map_claims_test.go
@@ -2,18 +2,18 @@ package jwt
 
 import "testing"
 
-func Test_mapClaims_list_aud(t *testing.T){
+func Test_mapClaims_list_aud(t *testing.T) {
 	mapClaims := MapClaims{}
-	mapClaims.set("aud", []string{"foo"})
+	mapClaims["aud"] = []string{"foo"}
 	want := true
 	got := mapClaims.VerifyAudience("foo", true)
 	if want != got {
 		t.Fatalf("Failed to verify claims, wanted: %v got %v", want, got)
 	}
 }
-func Test_mapClaims_string_aud(t *testing.T){
+func Test_mapClaims_string_aud(t *testing.T) {
 	mapClaims := MapClaims{}
-	mapClaims.set(	"aud", "foo")
+	mapClaims["aud"] = "foo"
 	want := true
 	got := mapClaims.VerifyAudience("foo", true)
 	if want != got {
@@ -21,27 +21,18 @@ func Test_mapClaims_string_aud(t *testing.T){
 	}
 }
 
-func Test_mapClaims_list_aud_no_match(t *testing.T){
+func Test_mapClaims_list_aud_no_match(t *testing.T) {
 	mapClaims := MapClaims{}
-	mapClaims.set("aud", []string{"bar"})
+	mapClaims["aud"] = []string{"bar"}
 	want := false
 	got := mapClaims.VerifyAudience("foo", true)
 	if want != got {
 		t.Fatalf("Failed to verify claims, wanted: %v got %v", want, got)
 	}
 }
-func Test_mapClaims_string_aud_fail(t *testing.T){
+func Test_mapClaims_string_aud_fail(t *testing.T) {
 	mapClaims := MapClaims{}
-	mapClaims.set("aud", "bar")
-	want := false
-	got := mapClaims.VerifyAudience("foo", true)
-	if want != got {
-		t.Fatalf("Failed to verify claims, wanted: %v got %v", want, got)
-	}
-}
-
-func Test_mapClaims_string_aud_no_claim(t *testing.T){
-	mapClaims := MapClaims{}
+	mapClaims["aud"] = "bar"
 	want := false
 	got := mapClaims.VerifyAudience("foo", true)
 	if want != got {
@@ -49,7 +40,16 @@ func Test_mapClaims_string_aud_no_claim(t *testing.T){
 	}
 }
 
-func Test_mapClaims_string_aud_no_claim_not_required(t *testing.T){
+func Test_mapClaims_string_aud_no_claim(t *testing.T) {
+	mapClaims := MapClaims{}
+	want := false
+	got := mapClaims.VerifyAudience("foo", true)
+	if want != got {
+		t.Fatalf("Failed to verify claims, wanted: %v got %v", want, got)
+	}
+}
+
+func Test_mapClaims_string_aud_no_claim_not_required(t *testing.T) {
 	mapClaims := MapClaims{}
 	want := false
 	got := mapClaims.VerifyAudience("foo", false)

--- a/map_claims_test.go
+++ b/map_claims_test.go
@@ -3,68 +3,56 @@ package jwt
 import "testing"
 
 func Test_mapClaims_list_aud(t *testing.T){
-	mapClaims := MapClaims{
-		"aud": []string{"foo"},
-	}
+	mapClaims := MapClaims{}
+	mapClaims.set("aud", []string{"foo"})
 	want := true
 	got := mapClaims.VerifyAudience("foo", true)
-
 	if want != got {
 		t.Fatalf("Failed to verify claims, wanted: %v got %v", want, got)
 	}
 }
 func Test_mapClaims_string_aud(t *testing.T){
-	mapClaims := MapClaims{
-		"aud": "foo",
-	}
+	mapClaims := MapClaims{}
+	mapClaims.set(	"aud", "foo")
 	want := true
 	got := mapClaims.VerifyAudience("foo", true)
-
 	if want != got {
 		t.Fatalf("Failed to verify claims, wanted: %v got %v", want, got)
 	}
 }
 
 func Test_mapClaims_list_aud_no_match(t *testing.T){
-	mapClaims := MapClaims{
-		"aud": []string{"bar"},
-	}
+	mapClaims := MapClaims{}
+	mapClaims.set("aud", []string{"bar"})
 	want := false
 	got := mapClaims.VerifyAudience("foo", true)
-
 	if want != got {
 		t.Fatalf("Failed to verify claims, wanted: %v got %v", want, got)
 	}
 }
 func Test_mapClaims_string_aud_fail(t *testing.T){
-	mapClaims := MapClaims{
-		"aud": "bar",
-	}
+	mapClaims := MapClaims{}
+	mapClaims.set("aud", "bar")
 	want := false
 	got := mapClaims.VerifyAudience("foo", true)
-
 	if want != got {
 		t.Fatalf("Failed to verify claims, wanted: %v got %v", want, got)
 	}
 }
 
 func Test_mapClaims_string_aud_no_claim(t *testing.T){
-	mapClaims := MapClaims{
-	}
+	mapClaims := MapClaims{}
 	want := false
 	got := mapClaims.VerifyAudience("foo", true)
-
 	if want != got {
 		t.Fatalf("Failed to verify claims, wanted: %v got %v", want, got)
 	}
 }
 
 func Test_mapClaims_string_aud_no_claim_not_required(t *testing.T){
-	mapClaims := MapClaims{
-	}
+	mapClaims := MapClaims{}
 	want := false
 	got := mapClaims.VerifyAudience("foo", false)
-
 	if want != got {
 		t.Fatalf("Failed to verify claims, wanted: %v got %v", want, got)
 	}

--- a/parser.go
+++ b/parser.go
@@ -58,12 +58,10 @@ func (p *Parser) ParseWithClaims(tokenString string, claims Claims, keyFunc Keyf
 		return token, &ValidationError{Inner: err, Errors: ValidationErrorUnverifiable}
 	}
 	vErr := &ValidationError{}
-
-	// Validate Claims
+	// Validate Claims.
 	if !p.SkipClaimsValidation {
-		var err error
-		if t, ok := token.Claims.(LeewayClaim); ok {
-			err = t.Leeway(p.Leeway).Valid()
+		if t, ok := token.Claims.(Leeway); ok {
+			err = t.Allow(p.Leeway).Valid()
 		} else {
 			err = token.Claims.Valid()
 		}

--- a/parser_test.go
+++ b/parser_test.go
@@ -173,6 +173,38 @@ var jwtTestData = []struct {
 		&jwt.Parser{UseJSONNumber: true},
 	},
 	{
+		"Validate iat and nbf with sufficient leeway",
+		"", // autogen
+		defaultKeyFunc,
+		&jwt.StandardClaims{
+			ExpiresAt: time.Now().Add(time.Minute * 5).Unix(),
+			IssuedAt:  time.Now().Add(time.Minute * 4).Unix(),
+			NotBefore: time.Now().Add(time.Minute * 4).Unix(),
+		},
+		true,
+		0,
+		&jwt.Parser{
+			UseJSONNumber: true,
+			Leeway:        5 * time.Minute,
+		},
+	},
+	{
+		"Validate iat and nbf with insufficient leeway",
+		"", // autogen
+		defaultKeyFunc,
+		&jwt.StandardClaims{
+			ExpiresAt: time.Now().Add(time.Minute * 5).Unix(),
+			IssuedAt:  time.Now().Add(time.Minute * 4).Unix(),
+			NotBefore: time.Now().Add(time.Minute * 4).Unix(),
+		},
+		false,
+		0,
+		&jwt.Parser{
+			UseJSONNumber: true,
+			Leeway:        1 * time.Minute,
+		},
+	},
+	{
 		"SkipClaimsValidation during token parsing",
 		"", // autogen
 		defaultKeyFunc,


### PR DESCRIPTION
This PR enables support for `leeway` through a defined interface, the underlying claims implementation can opt to implement this interface, as is the case of `StandardClaims`. Fairly basic and small change of scope. I did not apply changes for `MapClaims` although I did to provide an attempt however the scope change would be to major.

Please provide feedback. Thank you.