### PR TITLE
Fix security vulnerability

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/form3tech-oss/jwt-go
+
+go 1.16

--- a/map_claims.go
+++ b/map_claims.go
@@ -36,30 +36,38 @@ func (m MapClaims) VerifyAudience(cmp string, req bool) bool {
 // Compares the exp claim against cmp.
 // If required is false, this method will return true if the value matches or is unset
 func (m MapClaims) VerifyExpiresAt(cmp int64, req bool) bool {
-	switch exp := m["exp"].(type) {
+	exp, ok := m["exp"]
+	if !ok {
+		return !req
+	}
+	switch expType := exp.(type) {
 	case float64:
-		return verifyExp(int64(exp), cmp, req)
+		return verifyExp(int64(expType), cmp, req)
 	case json.Number:
-		v, _ := exp.Int64()
+		v, _ := expType.Int64()
 		return verifyExp(v, cmp, req)
 	}
-	return req == false
+	return false
 }
 
 // Compares the iat claim against cmp.
 // If required is false, this method will return true if the value matches or is unset
 func (m MapClaims) VerifyIssuedAt(cmp int64, req bool) bool {
-	switch iat := m["iat"].(type) {
+	iat, ok := m["iat"]
+	if !ok {
+		return !req
+	}
+	switch iatType := iat.(type) {
 	case float64:
-		return verifyIat(int64(iat), cmp, req)
+		return verifyIat(int64(iatType), cmp, req)
 	case json.Number:
-		v, _ := iat.Int64()
+		v, _ := iatType.Int64()
 		return verifyIat(v, cmp, req)
 	}
-	return req == false
+	return false
 }
 
-// Compares the iss claim against cmp.
+// Compares the iss claim against cmp.``
 // If required is false, this method will return true if the value matches or is unset
 func (m MapClaims) VerifyIssuer(cmp string, req bool) bool {
 	iss, _ := m["iss"].(string)
@@ -69,14 +77,18 @@ func (m MapClaims) VerifyIssuer(cmp string, req bool) bool {
 // Compares the nbf claim against cmp.
 // If required is false, this method will return true if the value matches or is unset
 func (m MapClaims) VerifyNotBefore(cmp int64, req bool) bool {
-	switch nbf := m["nbf"].(type) {
+	nbf, ok := m["nbf"]
+	if !ok {
+		return !req
+	}
+	switch nbfType := nbf.(type) {
 	case float64:
-		return verifyNbf(int64(nbf), cmp, req)
+		return verifyNbf(int64(nbfType), cmp, req)
 	case json.Number:
-		v, _ := nbf.Int64()
+		v, _ := nbfType.Int64()
 		return verifyNbf(v, cmp, req)
 	}
-	return req == false
+	return false
 }
 
 // Validates time based claims "exp, iat, nbf".
@@ -87,17 +99,17 @@ func (m MapClaims) Valid() error {
 	vErr := new(ValidationError)
 	now := TimeFunc().Unix()
 
-	if m.VerifyExpiresAt(now, false) == false {
+	if !m.VerifyExpiresAt(now, false) {
 		vErr.Inner = errors.New("Token is expired")
 		vErr.Errors |= ValidationErrorExpired
 	}
 
-	if m.VerifyIssuedAt(now, false) == false {
+	if !m.VerifyIssuedAt(now, false) {
 		vErr.Inner = errors.New("Token used before issued")
 		vErr.Errors |= ValidationErrorIssuedAt
 	}
 
-	if m.VerifyNotBefore(now, false) == false {
+	if !m.VerifyNotBefore(now, false) {
 		vErr.Inner = errors.New("Token is not valid yet")
 		vErr.Errors |= ValidationErrorNotValidYet
 	}

--- a/map_claims_test.go
+++ b/map_claims_test.go
@@ -57,6 +57,41 @@ func Test_mapClaims_string_aud_fail(t *testing.T) {
 	if want != got {
 		t.Fatalf("Failed to verify claims, wanted: %v got %v", want, got)
 	}
+
+}
+
+func Test_mapclaims_verify_issued_at_invalid_type_string(t *testing.T) {
+	mapClaims := MapClaims{
+		"iat": "foo",
+	}
+	want := false
+	got := mapClaims.VerifyIssuedAt(0, false)
+	if want != got {
+		t.Fatalf("Failed to verify claims, wanted: %v got %v", want, got)
+	}
+}
+
+func Test_mapclaims_verify_not_before_invalid_type_string(t *testing.T) {
+	mapClaims := MapClaims{
+		"nbf": "foo",
+	}
+	want := false
+	got := mapClaims.VerifyNotBefore(0, false)
+	if want != got {
+		t.Fatalf("Failed to verify claims, wanted: %v got %v", want, got)
+	}
+}
+
+func Test_mapclaims_verify_expires_at_invalid_type_string(t *testing.T) {
+	mapClaims := MapClaims{
+		"exp": "foo",
+	}
+	want := false
+	got := mapClaims.VerifyExpiresAt(0, false)
+
+	if want != got {
+		t.Fatalf("Failed to verify claims, wanted: %v got %v", want, got)
+	}
 }
 
 func Test_mapClaims_string_aud_no_claim(t *testing.T) {


### PR DESCRIPTION
## Issue
Right now, if you were to validate the expires_at, not_before, and issued_at jwt fields while not setting them up as required.. Even if the presented value was an invalid string, the verification would pass.

## Solution
Make sure that if the type is not expected, we return false. The presented solution should not cause any breaking changes.

Also, proceeded to add modules.